### PR TITLE
Rename date_updated to date_posted_or_crawled

### DIFF
--- a/home/migrations/0012_auto__chg_field_blog_created.py
+++ b/home/migrations/0012_auto__chg_field_blog_created.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Blog.created'
+        db.alter_column(u'home_blog', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'Blog.created'
+        db.alter_column(u'home_blog', 'created', self.gf('django.db.models.fields.DateTimeField')())
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'home.blog': {
+            'Meta': {'object_name': 'Blog'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_crawled': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'stream': ('django.db.models.fields.CharField', [], {'default': "'BLOGGING'", 'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'home.comment': {
+            'Meta': {'object_name': 'Comment'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'date_modified': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['home.Comment']", 'null': 'True', 'blank': 'True'}),
+            'post': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['home.Post']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'default': "'th2fUE'", 'unique': 'True', 'max_length': '6'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'home.hacker': {
+            'Meta': {'object_name': 'Hacker'},
+            'avatar_url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'github': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'twitter': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True'})
+        },
+        u'home.logentry': {
+            'Meta': {'object_name': 'LogEntry'},
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'post': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['home.Post']"}),
+            'referer': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'remote_addr': ('django.db.models.fields.IPAddressField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'home.post': {
+            'Meta': {'object_name': 'Post'},
+            'blog': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['home.Blog']"}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'default': "'K1dRt6'", 'unique': 'True', 'max_length': '6'}),
+            'title': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.TextField', [], {})
+        }
+    }
+
+    complete_apps = ['home']

--- a/home/models.py
+++ b/home/models.py
@@ -1,6 +1,10 @@
-from django.db import models
+import random
+import string
+
 from django.contrib.auth.models import User
-import random, string
+from django.db import models
+from django.utils import timezone
+
 
 def generate_random_id():
     return ''.join(random.choice(string.ascii_uppercase + string.digits + string.ascii_lowercase) for x in range(6))
@@ -40,7 +44,7 @@ class Post(models.Model):
     url          = models.TextField()
     title        = models.TextField(blank=True)
     content      = models.TextField()
-    date_updated = models.DateTimeField('date updated')
+    date_posted_or_crawled = models.DateTimeField('date updated')
     slug         = models.CharField(max_length=6, default=generate_random_id, unique=True)
 
 class Comment(models.Model):

--- a/home/models.py
+++ b/home/models.py
@@ -27,8 +27,9 @@ class Blog(models.Model):
     url          = models.URLField()
     feed_url     = models.URLField()
     last_crawled = models.DateTimeField('last crawled', blank=True, null=True)
-    created      = models.DateTimeField('date created')
+    created      = models.DateTimeField('date created', auto_now_add=True)
     stream       = models.CharField(max_length=100, default=STREAM_CHOICES[0][0], choices=STREAM_CHOICES)
+
 
 class Post(models.Model):
 

--- a/home/templates/home/atom.xml
+++ b/home/templates/home/atom.xml
@@ -5,13 +5,13 @@
   <link href="{{ domain }}/atom.xml" rel="self" />
   <link href="{{ domain }}" />
   <id>{{ domain }}</id>
-  <updated>{{ postList.0.date_updated|date:'Y-m-d\TH:i:s'}}</updated>
-  {% for post in postList %} 
+  <updated>{{ postList.0.date_posted_or_crawled|date:'Y-m-d\TH:i:s'}}</updated>
+  {% for post in postList %}
   <entry>
     <title>{{ post.title }}</title>
     <link href="{{ post.url }}" />
     <id>{{ post.url }}</id>
-    <updated>{{ post.date_updated|date:'Y-m-d\TH:i:s'}}</updated>
+    <updated>{{ post.date_posted_or_crawled|date:'Y-m-d\TH:i:s'}}</updated>
     <author>
       <name><![CDATA[{{ post.author }}]]></name>
     </author>

--- a/home/views.py
+++ b/home/views.py
@@ -131,7 +131,6 @@ def add_blog(request):
                 user=User.objects.get(id=request.user.id),
                 feed_url=feed_url,
                 url=url,
-                created=timezone.now(),
             )
 
             # this try/except is a janky bugfix. This should be done with celery

--- a/home/views.py
+++ b/home/views.py
@@ -143,7 +143,7 @@ def add_blog(request):
                         url=post_url,
                         title=post_title,
                         content="",
-                        date_updated=post_date,
+                        date_posted_or_crawled=post_date,
                     )
             except:
                 pass
@@ -168,7 +168,7 @@ def profile(request, user_id):
         added_blogs = Blog.objects.filter(user=user_id)
         owner = True if int(user_id) == request.user.id else False
 
-        post_list = Post.objects.filter(blog__user=user_id).order_by('-date_updated')
+        post_list = Post.objects.filter(blog__user=user_id).order_by('-date_posted_or_crawled')
         for post in post_list:
             post.stream     = post.blog.get_stream_display()
 
@@ -251,7 +251,7 @@ def new(request, page=1):
     end = start + items_per_page
     pages = int(math.ceil(Post.objects.count()/float(items_per_page)))
 
-    post_list = Post.objects.order_by('-date_updated')[start:end]
+    post_list = Post.objects.order_by('-date_posted_or_crawled')[start:end]
     for post in post_list:
         user            = User.objects.get(blog__id__exact=post.blog_id)
         post.author     = user.first_name + " " + user.last_name
@@ -285,11 +285,12 @@ def updated_avatar(request, user_id):
 
     return HttpResponse(hacker.avatar_url)
 
+
 @login_required
 def feed(request):
     ''' Atom feed of all new posts. '''
 
-    postList = list(Post.objects.all().order_by('-date_updated'))
+    postList = list(Post.objects.all().order_by('-date_posted_or_crawled'))
 
     for post in postList:
         user = User.objects.get(blog__id__exact=post.blog_id)


### PR DESCRIPTION
The date is now only set when the post is crawled for the first time.
Updates happen silently, because they are currently not used anywhere.

This also chooses the minimum of datetime.now() and the post's date when
setting the date for a Post.  This ensures that future dated posts
aren't always marked as "latest".

Fixes #114